### PR TITLE
Fixed newlines at the end of downloaded .json file, fixes #7

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -156,7 +156,7 @@ function downloadJson() {
         var data = bf.getData();
 
         var a = window.document.createElement('a');
-        a.href = window.URL.createObjectURL(new Blob([JSON.stringify(data, null, 4) + '\n\n'], { type: 'text/plain' }));
+        a.href = window.URL.createObjectURL(new Blob([`${JSON.stringify(data, null, 4)}\n`], { type: 'text/plain' }));
         a.download = document.getElementById('BrutusinForms#0_0').value + '.json';
         document.body.appendChild(a);
         a.click();


### PR DESCRIPTION
Downloaded .json file ends now with "...}\n".