### PR TITLE
Use key instead of keyCode, which is a deprecated feature.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -105,7 +105,7 @@ function loadSchema(schema) {
 
         element.addEventListener('keyup', function (event) {
             event.preventDefault();
-            if (event.keyCode === 13) {
+            if (event.key === 'Enter') {
                 formatPhoneNumber();
             }
         });
@@ -116,7 +116,7 @@ function loadSchema(schema) {
     // Add email helper
     getInputForLabelText('Email:').addEventListener('keyup', function (event) {
         event.preventDefault();
-        if (event.keyCode === 13 && confirm('Set suggested transport medium to email?')) {
+        if (event.key === 'Enter' && confirm('Set suggested transport medium to email?')) {
             var element = getInputForLabelText('Suggested transport medium:');
             element.value = 'email';
             triggerOnChange(element);
@@ -126,7 +126,7 @@ function loadSchema(schema) {
     // Add slug helpers
     getInputForLabelText('Website:').addEventListener('keyup', function (event) {
         event.preventDefault();
-        if (event.keyCode === 13 && confirm('Guess slug?')) {
+        if (event.key === 'Enter' && confirm('Guess slug?')) {
             var element = getInputForLabelText('Slug:');
             element.value = new URL(getInputForLabelText('Website:').value).hostname
                 .replace('www.', '')
@@ -136,7 +136,7 @@ function loadSchema(schema) {
     });
     getInputForLabelText('Name:').addEventListener('keyup', function (event) {
         event.preventDefault();
-        if (event.keyCode === 13 && confirm('Guess slug?')) {
+        if (event.key === 'Enter' && confirm('Guess slug?')) {
             var element = getInputForLabelText('Slug:');
             element.value = getInputForLabelText('Name:')
                 .value.toLowerCase()


### PR DESCRIPTION
Greetings,

[KeyboardEvent.keyCode](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) is deprecated and is no longer a recommended feature. One should use [KeyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) or [KeyboardEvent.code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) instead.

From the [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode):

> This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible; see the compatibility table at the bottom of this page to guide your decision. Be aware that this feature may cease to work at any time.