### PR TITLE
Update alert and error messages to use modals and popper

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "build": "parcel build src/*.html"
     },
     "dependencies": {
+        "bootbox": "^5.5.1",
         "bootstrap": "3",
         "brutusin-json-forms": "^0.0.0",
         "jquery": "^3.5.1",

--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,7 @@ require('brutusin-json-forms');
 require('brutusin-json-forms/dist/js/brutusin-json-forms-bootstrap');
 import Cookie from 'js-cookie';
 import { parsePhoneNumberFromString } from 'libphonenumber-js';
+import bootbox from 'bootbox';
 
 class InvalidCompanyRecord extends Error {
     constructor(json) {
@@ -18,9 +19,11 @@ function errorHandler(err) {
     if (err instanceof InvalidCompanyRecord) {
         document.getElementById('json-result').textContent =
             "Warning: Invalid record!\nWon't copy/download! \n\n" + JSON.stringify(err.json, null, 4);
-        alert('Warning: Record is not valid! Please correct before submitting.');
+        bootbox.alert(
+            "<p class='text-danger'><strong>Warning:</strong> Record is not valid! Please correct before submitting.</p>"
+        );
     } else {
-        throw err;
+        bootbox.alert(`<p class='text-danger'>${err}</p>`);
     }
 }
 
@@ -56,7 +59,7 @@ fetch(schema_url)
         loadSchema(out);
     })
     .catch((err) => {
-        throw err;
+        errorHandler(err);
     });
 
 function loadSchema(schema) {
@@ -75,6 +78,7 @@ function loadSchema(schema) {
     } catch (e) {
         template = null;
         console.error('Failed to parse JSON doc or template.', e);
+        errorHandler(e);
     }
 
     bf.render(container, template);
@@ -155,10 +159,12 @@ document.getElementById('btn-generate').onclick = function () {
 };
 document.getElementById('btn-download').onclick = downloadJson;
 document.getElementById('btn-clear').onclick = function () {
-    if (confirm('Do you really want to clear everything?')) {
-        window.location.hash = '';
-        window.location.reload(false);
-    }
+    bootbox.confirm('Do you really want to clear everything?', function (result) {
+        if (result) {
+            window.location.hash = '';
+            window.location.reload();
+        }
+    });
 };
 document.getElementById('btn-copy').onclick = function () {
     try {

--- a/src/style.css
+++ b/src/style.css
@@ -1,2 +1,6 @@
 @import 'bootstrap/dist/css/bootstrap.css';
 @import 'brutusin-json-forms/dist/css/brutusin-json-forms.css';
+
+.popover {
+    z-index: inherit;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,10 +1209,24 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bootbox@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/bootbox/-/bootbox-5.5.1.tgz#794908a0a0079544dfc38d177c441f3fa9b76c09"
+  integrity sha512-sAXwO4wgJipTrjAs77g3mCYdF59kxxPhQjG7rYPbHIp9AoAetPu77qvfJSBfmlezoEBdTs9ByfhOfb2W9IU7HQ==
+  dependencies:
+    bootstrap "^4.4.0"
+    jquery "^3.5.1"
+    popper.js "^1.16.0"
+
 bootstrap@3:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
   integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
+
+bootstrap@^4.4.0:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.3.tgz#c6a72b355aaf323920be800246a6e4ef30997fe6"
+  integrity sha512-o9ppKQioXGqhw8Z7mah6KdTYpNQY//tipnkxppWhPbiSWdD+1raYsnhwEZjkTHYbGee4cVQ0Rx65EhOY/HNLcQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -3705,6 +3719,11 @@ pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
+
+popper.js@^1.16.0:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
 posix-character-classes@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
- clearer to see where the errors are
- uses bootbox to simplify the modals

before:
![before](https://user-images.githubusercontent.com/16982271/96564036-83687000-1277-11eb-9d80-14ae338ed76c.png)
![before2](https://user-images.githubusercontent.com/16982271/96564040-84010680-1277-11eb-9eee-75b6c0aa4763.png)

after:
![2020-10-20 01_48_29-Window](https://user-images.githubusercontent.com/16982271/96564052-86fbf700-1277-11eb-8185-fdd90e27406f.png)
![2020-10-20 01_48_56-Window](https://user-images.githubusercontent.com/16982271/96564054-87948d80-1277-11eb-91ea-4d2a630d5d4a.png)
